### PR TITLE
Fix code scanning alert no. 10: Double escaping or unescaping

### DIFF
--- a/src/app/api/job-postings/route.js
+++ b/src/app/api/job-postings/route.js
@@ -63,7 +63,7 @@ function extractSalary(text) {
     .replace(/\u00a0/g, ' ')       // Replace non-breaking spaces
     .replace(/&nbsp;/g, ' ')       // Replace &nbsp;
     .replace(/&mdash;/g, '—')      // Replace &mdash; with em-dash
-    .replace(/&amp;/g, '&')        // Replace &amp; with &
+    // .replace(/&amp;/g, '&')        // Replace &amp; with &
     .replace(/&lt;/g, '<')         // Replace &lt; with <
     .replace(/&gt;/g, '>')         // Replace &gt; with >
     .trim();


### PR DESCRIPTION
Fixes [https://github.com/brycemcole/junera/security/code-scanning/10](https://github.com/brycemcole/junera/security/code-scanning/10)

To fix the problem, we need to remove the redundant replacement of `&amp;` with `&` on line 66. This will prevent the double unescaping issue. The `he.decode` function already handles the decoding of HTML entities, so additional replacements for `&amp;` are unnecessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
