### PR TITLE
Fix code scanning alert no. 9: Double escaping or unescaping

### DIFF
--- a/src/app/api/job-postings/[id]/route.js
+++ b/src/app/api/job-postings/[id]/route.js
@@ -24,9 +24,6 @@ function extractSalary(text) {
     .replace(/\u00a0/g, ' ')       // Replace non-breaking spaces
     .replace(/&nbsp;/g, ' ')       // Replace &nbsp;
     .replace(/&mdash;/g, '—')      // Replace &mdash; with em-dash
-    .replace(/&amp;/g, '&')        // Replace &amp; with &
-    .replace(/&lt;/g, '<')         // Replace &lt; with <
-    .replace(/&gt;/g, '>')         // Replace &gt; with >
     .trim();
 
   // Define regex patterns


### PR DESCRIPTION
Fixes [https://github.com/brycemcole/junera/security/code-scanning/9](https://github.com/brycemcole/junera/security/code-scanning/9)

To fix the problem, we should avoid performing additional replacements for HTML entities that have already been decoded by the `he.decode` function. Specifically, we should remove the lines that replace `&amp;`, `&lt;`, and `&gt;` with their corresponding characters, as these replacements are redundant and can lead to double unescaping.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
