### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "tailwindcss-animate": "^1.0.7",
     "use-debounce": "^10.0.4",
     "vaul": "^1.1.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "dompurify": "^3.2.3"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.0",

--- a/src/app/job-postings/[id]/page.js
+++ b/src/app/job-postings/[id]/page.js
@@ -52,6 +52,7 @@ import { Badge } from "@/components/ui/badge";
 import { JobCard } from "../../../components/job-posting";
 import { CollapsibleJobs } from "./collapsible";
 import { StickyNavbar } from './navbar';
+import DOMPurify from 'dompurify';
 const stripHTML = (str) => {
   const allowedTags = ['b', 'i', 'strong', 'br', 'em', 'u'];
   const parser = new DOMParser();
@@ -1016,7 +1017,7 @@ Please assess the qualifications and provide a brief explanation of whether the 
                       <p className="leading-loose text-sm">
                         <div
                           dangerouslySetInnerHTML={{
-                            __html: stripHTML(decodeHTMLEntities(jobPosting[key])),
+                            __html: DOMPurify.sanitize(stripHTML(decodeHTMLEntities(jobPosting[key]))),
                           }}
                         />
 


### PR DESCRIPTION
Fixes [https://github.com/brycemcole/junera/security/code-scanning/1](https://github.com/brycemcole/junera/security/code-scanning/1)

To fix the problem, we need to ensure that the HTML content is properly sanitized before being inserted into the DOM using `dangerouslySetInnerHTML`. We can use a well-known library like `DOMPurify` to sanitize the HTML content, which provides a more robust and comprehensive solution for preventing XSS attacks.

- Install the `dompurify` library.
- Import `DOMPurify` in the file.
- Use `DOMPurify.sanitize` to sanitize the HTML content before setting it with `dangerouslySetInnerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
